### PR TITLE
use fork of aicimageio that unpins from tifffile==0.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ requirements = [
     "torch>=1.0",
     "torchvision",
     "tqdm",
-    "aicsimageio",
+    "aicsimageio@git+https://github.com/donovanr/aicsimageio@master#egg=aicsimageio",
     "fnet@git+https://github.com/AllenCellModeling/pytorch_fnet@master#egg=fnet",
     "pytorch_learning_tools@git+https://github.com/AllenCellModeling/pytorch_learning_tools@master#egg=pytorch_learning_tools",
 ]


### PR DESCRIPTION
was getting a warning that tifffile._tifffle wasn't found during tests